### PR TITLE
Include QPainterPath and fix dependencies

### DIFF
--- a/.github/workflows/BuildTest.yaml
+++ b/.github/workflows/BuildTest.yaml
@@ -85,4 +85,4 @@ jobs:
         if: steps.check_rosdistro_repos_files.outputs.files_exists == 'false' && steps.check_repos_files.outputs.files_exists == 'false'
         with:
           ros2-distro: ${{ matrix.rosdistro }}
-          image-name: osrf/ros:humble-desktop-jammy
+          image-name: ros

--- a/.github/workflows/BuildTest.yaml
+++ b/.github/workflows/BuildTest.yaml
@@ -48,7 +48,7 @@ jobs:
           ros2-distro: ${{ matrix.rosdistro }}
 
   build_and_test_on_jammy:
-    name: Build
+    name: Build_jammy
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -85,3 +85,4 @@ jobs:
         if: steps.check_rosdistro_repos_files.outputs.files_exists == 'false' && steps.check_repos_files.outputs.files_exists == 'false'
         with:
           ros2-distro: ${{ matrix.rosdistro }}
+          image-name: osrf/ros:humble-desktop-jammy

--- a/.github/workflows/BuildTest.yaml
+++ b/.github/workflows/BuildTest.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rosdistro : [foxy, galactic, humble]
+        rosdistro : [foxy, galactic]
     steps:
       - uses: actions/checkout@v2-beta
       - name: Check dependency-${{ matrix.rosdistro }}.repos existence

--- a/.github/workflows/BuildTest.yaml
+++ b/.github/workflows/BuildTest.yaml
@@ -46,3 +46,42 @@ jobs:
         if: steps.check_rosdistro_repos_files.outputs.files_exists == 'false' && steps.check_repos_files.outputs.files_exists == 'false'
         with:
           ros2-distro: ${{ matrix.rosdistro }}
+
+  build_and_test_on_jammy:
+    name: Build
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        rosdistro : [humble]
+    steps:
+      - uses: actions/checkout@v2-beta
+      - name: Check dependency-${{ matrix.rosdistro }}.repos existence
+        id: check_rosdistro_repos_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: dependency-${{ matrix.rosdistro }}.repos
+          allow_failure: false
+      - name: Check dependency.repos existence
+        id: check_repos_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: dependency.repos
+          allow_failure: false
+      - name: Run OUXT-Polaris/ros2-ci@master with dependency-${{ matrix.rosdistro }}.repos
+        uses: OUXT-Polaris/ros2-ci@master
+        if: steps.check_rosdistro_repos_files.outputs.files_exists == 'true'
+        with:
+          ros2-distro: ${{ matrix.rosdistro }}
+          repos-filepath: dependency-${{ matrix.rosdistro }}.repos
+      - name: Run OUXT-Polaris/ros2-ci@master with dependency.repos
+        uses: OUXT-Polaris/ros2-ci@master
+        if: steps.check_rosdistro_repos_files.outputs.files_exists == 'false' && steps.check_repos_files.outputs.files_exists == 'true'
+        with:
+          ros2-distro: ${{ matrix.rosdistro }}
+          repos-filepath: dependency.repos
+      - name: Run OUXT-Polaris/ros2-ci@master without repos
+        uses: OUXT-Polaris/ros2-ci@master
+        if: steps.check_rosdistro_repos_files.outputs.files_exists == 'false' && steps.check_repos_files.outputs.files_exists == 'false'
+        with:
+          ros2-distro: ${{ matrix.rosdistro }}

--- a/.github/workflows/BuildTest.yaml
+++ b/.github/workflows/BuildTest.yaml
@@ -10,11 +10,11 @@ on:
 jobs:
   build_and_test:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        rosdistro : [foxy, galactic]
+        rosdistro : [foxy, galactic, humble]
     steps:
       - uses: actions/checkout@v2-beta
       - name: Check dependency-${{ matrix.rosdistro }}.repos existence
@@ -46,43 +46,4 @@ jobs:
         if: steps.check_rosdistro_repos_files.outputs.files_exists == 'false' && steps.check_repos_files.outputs.files_exists == 'false'
         with:
           ros2-distro: ${{ matrix.rosdistro }}
-
-  build_and_test_on_jammy:
-    name: Build_jammy
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        rosdistro : [humble]
-    steps:
-      - uses: actions/checkout@v2-beta
-      - name: Check dependency-${{ matrix.rosdistro }}.repos existence
-        id: check_rosdistro_repos_files
-        uses: andstor/file-existence-action@v1
-        with:
-          files: dependency-${{ matrix.rosdistro }}.repos
-          allow_failure: false
-      - name: Check dependency.repos existence
-        id: check_repos_files
-        uses: andstor/file-existence-action@v1
-        with:
-          files: dependency.repos
-          allow_failure: false
-      - name: Run OUXT-Polaris/ros2-ci@master with dependency-${{ matrix.rosdistro }}.repos
-        uses: OUXT-Polaris/ros2-ci@master
-        if: steps.check_rosdistro_repos_files.outputs.files_exists == 'true'
-        with:
-          ros2-distro: ${{ matrix.rosdistro }}
-          repos-filepath: dependency-${{ matrix.rosdistro }}.repos
-      - name: Run OUXT-Polaris/ros2-ci@master with dependency.repos
-        uses: OUXT-Polaris/ros2-ci@master
-        if: steps.check_rosdistro_repos_files.outputs.files_exists == 'false' && steps.check_repos_files.outputs.files_exists == 'true'
-        with:
-          ros2-distro: ${{ matrix.rosdistro }}
-          repos-filepath: dependency.repos
-      - name: Run OUXT-Polaris/ros2-ci@master without repos
-        uses: OUXT-Polaris/ros2-ci@master
-        if: steps.check_rosdistro_repos_files.outputs.files_exists == 'false' && steps.check_repos_files.outputs.files_exists == 'false'
-        with:
-          ros2-distro: ${{ matrix.rosdistro }}
-          image-name: ros
+          image-name: ros    # Docker Official Image

--- a/.github/workflows/BuildTest.yaml
+++ b/.github/workflows/BuildTest.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rosdistro : [foxy, galactic]
+        rosdistro : [foxy, galactic, humble]
     steps:
       - uses: actions/checkout@v2-beta
       - name: Check dependency-${{ matrix.rosdistro }}.repos existence

--- a/jsk_rviz_plugins/CMakeLists.txt
+++ b/jsk_rviz_plugins/CMakeLists.txt
@@ -16,10 +16,10 @@ find_package(ament_cmake REQUIRED)
 find_package(rviz_common REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(rviz_ogre_vendor REQUIRED)
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Test REQUIRED)
+find_package(Qt5 REQUIRED COMPONENTS Widgets Test)
 find_package(image_transport REQUIRED)
 find_package(cv_bridge REQUIRED)
+find_package(Boost REQUIRED)
 
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -46,7 +46,7 @@ find_package(jsk_rviz_plugin_msgs REQUIRED)
 find_package(jsk_topic_tools REQUIRED)
 
 # for Ogre include files
-include_directories(${ADDITIONAL_INCLUDE_DIRS} ${OGRE_INCLUDE_DIRS} ${OGRE_INCLUDE_DIRS}/Paging)
+include_directories(${ADDITIONAL_INCLUDE_DIRS} ${OGRE_INCLUDE_DIRS} ${OGRE_INCLUDE_DIRS}/Paging ${Boost_INCLUDE_DIRS})
 
 # Qt5 boilerplate options from http://doc.qt.io/qt-5/cmake-manual.html
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -157,8 +157,6 @@ ament_export_libraries(jsk_rviz_plugins)
 # ament_export_include_directories(include)
 ament_export_targets(export_jsk_rviz_plugins HAS_LIBRARY_TARGET)
 ament_export_dependencies(
-  Qt5Widgets
-  Qt5Test
   rviz_common
   cv_bridge
   image_transport

--- a/jsk_rviz_plugins/CMakeLists.txt
+++ b/jsk_rviz_plugins/CMakeLists.txt
@@ -16,7 +16,8 @@ find_package(ament_cmake REQUIRED)
 find_package(rviz_common REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(rviz_ogre_vendor REQUIRED)
-find_package(Qt5 REQUIRED COMPONENTS Widgets Test)
+find_package(Qt5Widgets REQUIRED)
+find_package(Qt5Test REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(cv_bridge REQUIRED)
 
@@ -35,6 +36,7 @@ find_package(tf2_ros REQUIRED)
 find_package(urdf REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
+find_package(actionlib_msgs REQUIRED)
 
 find_package(jsk_footstep_msgs REQUIRED)
 find_package(jsk_gui_msgs REQUIRED)
@@ -120,6 +122,7 @@ ament_target_dependencies(jsk_rviz_plugins
   geometry_msgs
   nav_msgs
   diagnostic_msgs
+  actionlib_msgs
   jsk_footstep_msgs
   jsk_gui_msgs
   jsk_hark_msgs
@@ -128,11 +131,11 @@ ament_target_dependencies(jsk_rviz_plugins
   jsk_topic_tools
   )
 
-target_include_directories(jsk_rviz_plugins
-  PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-  )
+# target_include_directories(jsk_rviz_plugins
+#   PUBLIC
+#   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+#   $<INSTALL_INTERFACE:include>
+#   )
 
 if (NOT WIN32)
   ament_environment_hooks(
@@ -151,10 +154,11 @@ pluginlib_export_plugin_description_file(rviz_common plugins_description.xml)
 # replaces catkin_package(LIBRARIES jsk_rviz_plugins) 
 ament_export_libraries(jsk_rviz_plugins)
 
-ament_export_include_directories(include)
+# ament_export_include_directories(include)
 ament_export_targets(export_jsk_rviz_plugins HAS_LIBRARY_TARGET)
 ament_export_dependencies(
-  Qt5
+  Qt5Widgets
+  Qt5Test
   rviz_common
   cv_bridge
   image_transport
@@ -171,6 +175,7 @@ ament_export_dependencies(
   urdf
   visualization_msgs
   diagnostic_msgs
+  actionlib_msgs
   jsk_footstep_msgs
   jsk_gui_msgs
   jsk_hark_msgs
@@ -190,7 +195,7 @@ install(TARGETS
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
+  # INCLUDES DESTINATION include
   )
 
 install(DIRECTORY

--- a/jsk_rviz_plugins/package.xml
+++ b/jsk_rviz_plugins/package.xml
@@ -46,6 +46,7 @@
   <depend>urdf</depend>
   <depend>visualization_msgs</depend>
   <depend>diagnostic_msgs</depend>
+  <depend>actionlib_msgs</depend>
   <depend>jsk_footstep_msgs</depend>
   <depend>jsk_gui_msgs</depend>
   <depend>jsk_hark_msgs</depend>

--- a/jsk_rviz_plugins/package.xml
+++ b/jsk_rviz_plugins/package.xml
@@ -19,6 +19,7 @@
 
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>rviz_ogre_vendor</build_depend>
+  <build_depend>boost</build_depend>
   <build_export_depend>rviz_ogre_vendor</build_export_depend>
 
   <exec_depend>libqt5-core</exec_depend>

--- a/jsk_rviz_plugins/src/overlay_diagnostic_display.hpp
+++ b/jsk_rviz_plugins/src/overlay_diagnostic_display.hpp
@@ -37,6 +37,7 @@
 #include <OgreTexture.h>
 
 #include <QPainter>
+#include <QPainterPath>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <rviz_common/properties/color_property.hpp>


### PR DESCRIPTION
- Include QPainterPath  to `jsk_rviz_plugins/src/overlay_diagnostic_display.hpp`
- Fix some dependencies
- Remove entries about missing include directories from  `jsk_rviz_plugins/CMakeLists.txt`

The build has passed on ROS2 Humble, but I haven't tested.