### PR TITLE
Support building on ROS 2 Jazzy

### DIFF
--- a/jsk_rviz_plugins/CMakeLists.txt
+++ b/jsk_rviz_plugins/CMakeLists.txt
@@ -137,12 +137,6 @@ ament_target_dependencies(jsk_rviz_plugins
 #   $<INSTALL_INTERFACE:include>
 #   )
 
-if (NOT WIN32)
-  ament_environment_hooks(
-    "${ament_cmake_package_templates_ENVIRONMENT_HOOK_LIBRARY_PATH}"
-  )
-endif()
-
 # Link non ament packages
 target_link_libraries(jsk_rviz_plugins Qt5::Widgets)
 

--- a/jsk_rviz_plugins/src/overlay_image_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_image_display.cpp
@@ -35,7 +35,12 @@
 #include <OgreTechnique.h>
 #include <OgreTexture.h>
 #include <OgreTextureManager.h>
+
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
 #include <cv_bridge/cv_bridge.hpp>
+#else
+#include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <rviz_common/uniform_string_stream.hpp>
 #include <sensor_msgs/image_encodings.hpp>

--- a/jsk_rviz_plugins/src/overlay_image_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_image_display.cpp
@@ -35,7 +35,7 @@
 #include <OgreTechnique.h>
 #include <OgreTexture.h>
 #include <OgreTextureManager.h>
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 
 #include <rviz_common/uniform_string_stream.hpp>
 #include <sensor_msgs/image_encodings.hpp>

--- a/jsk_topic_tools/CMakeLists.txt
+++ b/jsk_topic_tools/CMakeLists.txt
@@ -47,11 +47,6 @@ target_include_directories(jsk_topic_tools_node
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
-if (NOT WIN32)
-  ament_environment_hooks(
-    "${ament_cmake_package_templates_ENVIRONMENT_HOOK_LIBRARY_PATH}")
-endif()
-
 ament_export_targets(export_jsk_topic_tools_node HAS_LIBRARY_TARGET)
 ament_export_dependencies(rclcpp)
 ament_export_libraries(jsk_topic_tools_node)


### PR DESCRIPTION
### Changes

- Use `cv_bridge.hpp` instead of `cv_bridge.h` because of deprecation
- Modify CMakeLists to fix errors

Currently, some deprecation warnings are shown, but build is OK.